### PR TITLE
Update Observable+Combine

### DIFF
--- a/Sources/Rx+Combine/Observable+Combine.swift
+++ b/Sources/Rx+Combine/Observable+Combine.swift
@@ -12,7 +12,7 @@ import RxSwift
 public extension ObservableConvertibleType {
     /// An `AnyPublisher` of the underlying Observable's Element type
     /// so the Observable pushes events to the Publisher.
-    var publisher: AnyPublisher<Element, Swift.Error> {
+    func asPublisher() -> AnyPublisher<Element, Swift.Error> {
         return AnyPublisher<Element, Swift.Error> { subscriber in
             subscriber.receive(subscription: RxSubscription(disposable: self.asObservable()
                                                                             .subscribe(subscriber.pushRxEvent)))

--- a/Sources/Rx+Combine/Observable+Combine.swift
+++ b/Sources/Rx+Combine/Observable+Combine.swift
@@ -14,9 +14,10 @@ public extension ObservableConvertibleType {
     ///
     /// - returns: AnyPublisher<Element, Swift.Error>
     func asPublisher() -> AnyPublisher<Element, Swift.Error> {
-        return AnyPublisher<Element, Swift.Error> { subscriber in
-            subscriber.receive(subscription: RxSubscription(disposable: self.asObservable()
-                                                                            .subscribe(subscriber.pushRxEvent)))
+        AnyPublisher<Element, Swift.Error> { subscriber in
+            subscriber.receive(
+                subscription: RxSubscription(disposable: self.asObservable().subscribe(subscriber.pushRxEvent))
+            )
         }
     }
 }

--- a/Sources/Rx+Combine/Observable+Combine.swift
+++ b/Sources/Rx+Combine/Observable+Combine.swift
@@ -10,8 +10,9 @@ import Combine
 import RxSwift
 
 public extension ObservableConvertibleType {
-    /// An `AnyPublisher` of the underlying Observable's Element type
-    /// so the Observable pushes events to the Publisher.
+    /// Return an `AnyPublisher`, representing the underlying Observable's Element type.
+    ///
+    /// - returns: AnyPublisher<Element, Swift.Error>
     func asPublisher() -> AnyPublisher<Element, Swift.Error> {
         return AnyPublisher<Element, Swift.Error> { subscriber in
             subscriber.receive(subscription: RxSubscription(disposable: self.asObservable()


### PR DESCRIPTION
First of all, thank you for `RxCombine` @freak4pc! 🎉

In this PR, I changed the implementation in `Observable+Combine`. 
Instead of exposing a computed property, `publisher`, I expose a method, `asPublisher`, that converts an `Observable` to a `AnyPublisher`.

Following the similar idea as [here](https://github.com/freak4pc/RxCombine/blob/master/Sources/Combine%2BRx/Publisher%2BRx.swift).

What do you think?