### PR TITLE
Fix "Received value before receiving subscription" crash.

### DIFF
--- a/Sources/Rx+Combine/Observable+Combine.swift
+++ b/Sources/Rx+Combine/Observable+Combine.swift
@@ -14,10 +14,12 @@ public extension ObservableConvertibleType {
     /// so the Observable pushes events to the Publisher.
     var publisher: AnyPublisher<Element, Swift.Error> {
         AnyPublisher<Element, Swift.Error> { subscriber in
+            let disposable = SingleAssignmentDisposable()
             subscriber.receive(
-                subscription: RxSubscription(disposable: self.asObservable()
-                                                             .subscribe(subscriber.pushRxEvent))
+                subscription: RxSubscription(disposable: disposable)
             )
+            disposable.setDisposable(self.asObservable()
+                                         .subscribe(subscriber.pushRxEvent))
         }
     }
     


### PR DESCRIPTION
Thanks for the code. Appreciate you sharing your work.

Fix crash caused by Observables that send a value synchronously while being subscribed to. Combine requires receiving the subscription event before receiving and value events.